### PR TITLE
Finished SystemNotStructuredScanner

### DIFF
--- a/src/Reports/Report.java
+++ b/src/Reports/Report.java
@@ -139,9 +139,11 @@ public abstract class Report {
 
     public static Report getReport(String input) {
         if(input.equals("SourceAnalysis")) {
-            return sourceAnalysis;
+            //return sourceAnalysis;
+            return new SourceAnalysis();
         } else if(input.equals("SourceReview")) {
-            return sourceReview;
+            //return sourceReview;
+            return new SourceReview();
         }
         return null;
     }

--- a/src/Reports/SourceReview.java
+++ b/src/Reports/SourceReview.java
@@ -13,7 +13,7 @@ public class SourceReview extends Report {
     private final String TITLE = "Source Analysis Summary";
 
     /**
-     * The constructor for the SourceAnalysis
+     * The constructor for the SourceReview
      */
     public SourceReview() {
         this.totalLinesArrayPos = -1;
@@ -33,7 +33,7 @@ public class SourceReview extends Report {
         scans.add(new NestdInclScanner());
         scans.add(new ProcedureOver250Scanner());
         scans.add(new GotoScanner());
-        scans.add(new SystemNotStructured());
+        scans.add(new SystemNotStructuredScanner());
         scans.add(new MisplacedEndSysScanner());
         scans.add(new IncorrectFileExtension());
         scans.add(new MultipleComponentsScanner());

--- a/src/Scans/ProcedureOver250Scanner.java
+++ b/src/Scans/ProcedureOver250Scanner.java
@@ -13,9 +13,9 @@ public class ProcedureOver250Scanner extends Scan {
 
     private boolean inProcBlock;
     public static TreeSet<String> procNames = new TreeSet<>();
-    public static TreeSet<String> fileNames = new TreeSet<>();
+//    public static TreeSet<String> fileNames = new TreeSet<>();
     private String procName;
-    private String fileName = "..";
+//    private String fileName = "..";
 
     /**
      * Constructor for ProcedureOver250Scanner.
@@ -44,7 +44,7 @@ public class ProcedureOver250Scanner extends Scan {
             count += statement.getNumLines();
             if (count > 250) {
                 procNames.add(procName);
-                fileNames.add(fileName);
+//                fileNames.add(fileName);
                 inProcBlock = false; // no need to check for more lines
             }
         }

--- a/src/Scans/SystemNotStructuredScanner.java
+++ b/src/Scans/SystemNotStructuredScanner.java
@@ -1,0 +1,89 @@
+package Scans;
+
+import CMS2Statements.Statement;
+import Reports.Entry;
+
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.TreeSet;
+
+/**
+ * This class scans code to see how often it deviates from the compile time structure
+ */
+public class SystemNotStructuredScanner extends Scan {
+
+    private ArrayList<String> structure;
+    /**
+     * Constructor for SystemNotStructuredScanner.
+     */
+    public SystemNotStructuredScanner() {
+        KEYWORD = "NotStructured";
+        count = 0;
+        structure = new ArrayList<String>();
+    }
+
+    /**
+     * Scans a statement and counts it if it deviates from the compile-time structure.
+     * @param statement The statement to be scanned
+     */
+    public void scan(Statement statement) {
+        String s = getFirstToken(statement.getText());
+        if (!statement.isDirectCode()) {
+            if (s.equals("SYSTEM")) {
+                if (!structure.isEmpty())
+                    count++;
+                structure.add("SYSTEM");
+            } else if (s.equals("HEAD")) {
+                if (!structure.get(structure.size()-1).equals("SYSTEM"))
+                    count++;
+                structure.add("HEAD");
+            } else if (s.equals("END-HEAD")) {
+                if (!structure.get(structure.size()-1).equals("HEAD"))
+                    count++;
+                structure.add("END-HEAD");
+            } else if (s.equals("SYS-DD")) {
+                if (!structure.get(structure.size()-1).equals("END-HEAD"))
+                    count++;
+                structure.add("SYS-DD");
+            } else if (s.equals("END-SYS-DD")) {
+                if (!structure.get(structure.size()-1).equals("SYS-DD"))
+                    count++;
+                structure.add("END-SYS-DD");
+            } else if (s.equals("SYS-PROC")) {
+                if (!structure.get(structure.size()-1).equals("END-SYS-DD"))
+                    count++;
+                structure.add("SYS-PROC");
+            } else if (s.equals("PROCEDURE")) {
+                if (!structure.get(structure.size()-1).equals("SYS-PROC"))
+                    count++;
+                structure.add("PROCEDURE");
+            } else if (s.equals("END-PROC")) {
+                if (!structure.get(structure.size()-1).equals("PROCEDURE"))
+                    count++;
+                else structure.remove(structure.size()-1); // in case there are other procedures
+            } else if (s.equals("END-SYS-PROC")) {
+                if (!structure.get(structure.size()-1).equals("SYS-PROC"))
+                    count++;
+                structure.add("END-SYS-PROC");
+            } else if (s.equals("END-SYSTEM")) {
+                if (!structure.get(structure.size()-1).equals("END-SYS-PROC"))
+                    count++;
+                structure.add("END-SYSTEM");
+            } else if (structure.get(structure.size()-1).equals("END-SYSTEM")) {
+                count++;
+            }
+        }
+    }
+
+    /**
+     * Overrides Scan's getData() method so that it returns how many occurrences are found
+     * @return number of occurrences
+     */
+    public ArrayList<Entry> getData() {
+        ArrayList<Entry> data = new ArrayList<Entry>();
+
+        data.add(new Entry(KEYWORD + " Occurences", count));
+
+        return data;
+    }
+}


### PR DESCRIPTION
I didn't realize we already had a SystemNotStructured file when making this scanner, so... yeah. The scanner is very strict about what can be considered properly structured. The compile-time structure diagram we have on Google Drive was used as a reference. If your test files do not match this structure, this scanner should notice.
I also realized a problem with a design change. Someone accidentally made it so that the same report was used for all FileScanners, resulting in data from scanners carrying over to all files that followed. I fixed this by changing getReport() in the Report class.